### PR TITLE
Fix 2 buggy tools, add User-Agent header, and 10 new tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,18 @@ A minimal Canvas LMS MCP (Machine Conversation Protocol) server for easy access 
 
 ## Features
 
-- List planner items (assignments, quizzes, etc.)
-- Get and list assignments
-- Get and list quizzes
-- Get and list courses
-- Get course syllabus
-- Get course modules
-- List files
+- **Courses**: List enrolled courses, get course details, syllabus, modules, and module items
+- **Assignments**: List and get assignments with optional submission status
+- **Pages**: Get course pages by URL slug
+- **Submissions**: List your own submissions with grades and feedback
+- **Announcements**: List announcements across multiple courses
+- **Discussions**: List topics and view full discussion threads
+- **Calendar**: List calendar events with date filtering
+- **Planner**: List planner items (assignments, announcements, etc.)
+- **Enrollments**: Get enrollment data with grades
+- **Quizzes**: List and get quizzes (classic quizzes only)
+- **Files**: List and get files
+- **Navigation**: Get course tabs, assignment groups, and favorite courses
 
 ## Installation
 
@@ -100,7 +105,7 @@ By default, the server runs on http://localhost:8000. You can use the FastMCP in
 
 ## Available Tools
 
-The server provides the following tools for interacting with Canvas LMS:
+The server provides 22 tools for interacting with Canvas LMS:
 
 ### Courses
 
@@ -119,7 +124,7 @@ Parameters:
 - `include` (optional): List of additional data to include
 
 #### `get_course_syllabus`
-Get a course's syllabus.
+Get a course's syllabus body as HTML.
 
 Parameters:
 - `course_id` (required): Course ID
@@ -130,6 +135,14 @@ Get modules for a course.
 Parameters:
 - `course_id` (required): Course ID
 - `include` (optional): List of additional data to include
+- `per_page` (optional, default=100): Number of items per page
+
+#### `get_module_items`
+Get items for a specific module.
+
+Parameters:
+- `course_id` (required): Course ID
+- `module_id` (required): Module ID
 
 ### Assignments
 
@@ -138,8 +151,9 @@ List assignments for a course.
 
 Parameters:
 - `course_id` (required): Course ID
-- `bucket` (required): Filter assignments by ("past", "overdue", "undated", "ungraded", "unsubmitted", "upcoming", "future")
-- `order_by` (required): Field to order assignments by ("due_at", "position", "name")
+- `bucket` (required): Filter by "past", "overdue", "undated", "ungraded", "unsubmitted", "upcoming", or "future"
+- `order_by` (required): Order by "due_at", "position", or "name"
+- `include` (optional): List of additional data to include (e.g., `["submission"]` to see grade status)
 - `page` (optional, default=1): Page number (1-indexed)
 - `items_per_page` (optional, default=10): Number of items per page
 
@@ -150,10 +164,92 @@ Parameters:
 - `course_id` (required): Course ID
 - `assignment_id` (required): Assignment ID
 
+#### `list_assignment_groups`
+List assignment groups for a course (shows grade weighting/categories).
+
+Parameters:
+- `course_id` (required): Course ID
+
+### Pages
+
+#### `get_page`
+Get a single page by its URL slug.
+
+Parameters:
+- `course_id` (required): Course ID
+- `page_slug` (required): Page URL slug (e.g., "syllabus", "course-handbook")
+
+### Submissions
+
+#### `list_submissions`
+List the current user's submissions for a course, including grades and feedback.
+
+Parameters:
+- `course_id` (required): Course ID
+- `include` (optional): List of additional data (e.g., `["assignment", "submission_comments"]`)
+- `page` (optional, default=1): Page number (1-indexed)
+- `items_per_page` (optional, default=10): Number of items per page
+
+### Announcements
+
+#### `list_announcements`
+List announcements for one or more courses.
+
+Parameters:
+- `course_ids` (required): List of course IDs
+- `page` (optional, default=1): Page number (1-indexed)
+- `items_per_page` (optional, default=10): Number of items per page
+
+### Discussions
+
+#### `list_discussions`
+List discussion topics for a course.
+
+Parameters:
+- `course_id` (required): Course ID
+- `page` (optional, default=1): Page number (1-indexed)
+- `items_per_page` (optional, default=10): Number of items per page
+
+#### `get_discussion_view`
+Get the full view of a discussion topic including all replies.
+
+Parameters:
+- `course_id` (required): Course ID
+- `discussion_id` (required): Discussion topic ID
+
+### Calendar
+
+#### `list_calendar_events`
+List calendar events for courses.
+
+Parameters:
+- `context_codes` (required): List of context codes (e.g., `["course_123"]`)
+- `start_date` (optional): Start date in ISO 8601 format
+- `end_date` (optional): End date in ISO 8601 format
+- `page` (optional, default=1): Page number (1-indexed)
+- `items_per_page` (optional, default=10): Number of items per page
+
+### Planner Items
+
+#### `list_planner_items`
+List planner items for the authenticated user.
+
+Parameters:
+- `start_date` (required): Start date in ISO 8601 format
+- `end_date` (required): End date in ISO 8601 format
+- `context_codes` (optional): List of context codes (e.g., `["course_123"]`)
+- `page` (optional, default=1): Page number (1-indexed)
+- `items_per_page` (optional, default=10): Number of items per page
+
+### Enrollments
+
+#### `get_enrollments`
+Get the current user's enrollments including grades.
+
 ### Quizzes
 
 #### `list_quizzes`
-List quizzes for a course.
+List quizzes for a course. Note: only works with Classic Quizzes, not New Quizzes (quiz_lti).
 
 Parameters:
 - `course_id` (required): Course ID
@@ -171,7 +267,7 @@ Parameters:
 ### Files
 
 #### `list_files`
-List files for a course or folder.
+List files for a course or folder. Note: may return 403 for student accounts depending on institution permissions.
 
 Parameters:
 - `course_id` (optional): Course ID
@@ -180,17 +276,23 @@ Parameters:
 - `page` (optional, default=1): Page number (1-indexed)
 - `items_per_page` (optional, default=10): Number of items per page
 
-### Planner Items
-
-#### `list_planner_items`
-List planner items for the authenticated user.
+#### `get_file`
+Get a file by ID. Works with known file IDs even when `list_files` is restricted.
 
 Parameters:
-- `start_date` (required): Start date in ISO 8601 format
-- `end_date` (required): End date in ISO 8601 format
-- `context_codes` (optional): List of context codes (e.g., ["course_123"])
-- `page` (optional, default=1): Page number (1-indexed)
-- `items_per_page` (optional, default=10): Number of items per page
+- `course_id` (required): Course ID
+- `file_id` (required): File ID
+
+### Other
+
+#### `get_tabs`
+Get available tabs/navigation items for a course.
+
+Parameters:
+- `course_id` (required): Course ID
+
+#### `list_favorites`
+List the current user's favorite courses.
 
 ## Integration with Cursor
 

--- a/README.md
+++ b/README.md
@@ -294,75 +294,75 @@ Parameters:
 #### `list_favorites`
 List the current user's favorite courses.
 
-## Integration with Cursor
+## Integration
 
-Cursor is an AI-powered IDE that can interact with the Canvas LMS MCP server to provide education data directly within your development environment.
+This MCP server works with any client that supports the [Model Context Protocol](https://modelcontextprotocol.io/), including Claude Desktop, Claude Code, Cursor, Windsurf, and others.
 
-### Setting Up Cursor Integration
-
-1. Install the Cursor IDE from [https://cursor.sh/](https://cursor.sh/)
-
-2. Create a `.cursor/mcp.json` file in your project directory with the following content:
-   ```json
-   {
-       "mcpServers": {
-           "canvas": {
-               "command": "uvx",
-               "args": [
-                    "canvas-lms-mcp"
-               ],
-               "env": {
-                   "CANVAS_API_TOKEN": "your_canvas_api_token",
-                   "CANVAS_BASE_URL": "https://your-institution.instructure.com"
-               }
-           }
-       }
-   }
-   ```
-
-   Replace:
-   - `your_canvas_api_token` with your actual Canvas API token
-   - `your-institution.instructure.com` with your Canvas institution URL
-
-3. Restart Cursor for the changes to take effect.
-
-### Cursor Time Integration (Optional)
-
-You can also integrate a time server for timezone-related queries by adding a "time" server to your mcp.json:
+The MCP configuration is the same across all clients — only the config file location differs:
 
 ```json
-"time": {
-    "command": "uvx",
-    "args": [
-        "mcp-server-time",
-        "--local-timezone=America/New_York"
-    ]
+{
+    "mcpServers": {
+        "canvas": {
+            "command": "uvx",
+            "args": ["canvas-lms-mcp"],
+            "env": {
+                "CANVAS_API_TOKEN": "your_canvas_api_token",
+                "CANVAS_BASE_URL": "https://your-institution.instructure.com"
+            }
+        }
+    }
 }
 ```
 
-This allows you to use time-related functions with your Canvas data.
+Replace `your_canvas_api_token` with your Canvas API token (found in Canvas → Account → Settings → New Access Token) and `your-institution.instructure.com` with your institution's Canvas URL.
+
+### Claude Desktop
+
+Add to your Claude Desktop config file:
+
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Restart Claude Desktop after saving.
+
+### Claude Code
+
+Add to your project's `.mcp.json` or global `~/.claude/settings.json`:
+
+```json
+{
+    "mcpServers": {
+        "canvas": {
+            "command": "uvx",
+            "args": ["canvas-lms-mcp"],
+            "env": {
+                "CANVAS_API_TOKEN": "your_canvas_api_token",
+                "CANVAS_BASE_URL": "https://your-institution.instructure.com"
+            }
+        }
+    }
+}
+```
+
+### Cursor
+
+Add to `.cursor/mcp.json` in your project directory. Restart Cursor after saving.
+
+### Windsurf
+
+Add to `~/.codeium/windsurf/mcp_config.json`. Restart Windsurf after saving.
 
 ### Usage Examples
 
-Once connected, you can ask Cursor AI about your Canvas data:
+Once connected, you can ask your AI assistant about your Canvas data:
 
 - "What assignments do I have due next week?"
 - "Show me the syllabus for my Biology course"
-- "List all my upcoming quizzes"
+- "What announcements were posted today?"
+- "What are my grades so far?"
 - "What's on my schedule for tomorrow?"
-
-Example conversation:
-
-```
-YOU: What assignments do I have due soon?
-
-CURSOR: I'll check your upcoming assignments.
-
-Based on your Canvas data, here are your upcoming assignments:
-- "Final Project" for CS101 due on December 10, 2023
-- "Lab Report #5" for BIOL200 due on December 7, 2023
-- "Research Paper" for ENGL301 due on December 15, 2023
-```
+- "Show me the discussion posts for my English class"
 
 ## Development
 

--- a/src/canvas_lms_mcp/client.py
+++ b/src/canvas_lms_mcp/client.py
@@ -24,6 +24,7 @@ class CanvasClient:
                 headers={
                     "Authorization": f"Bearer {api_token}",
                     "Content-Type": "application/json",
+                    "User-Agent": "canvas-lms-mcp/0.1.3",
                 },
             )
             self._initialized = True

--- a/src/canvas_lms_mcp/main.py
+++ b/src/canvas_lms_mcp/main.py
@@ -6,14 +6,22 @@ from fastmcp import FastMCP
 
 from canvas_lms_mcp.client import CanvasClient
 from canvas_lms_mcp.schema import (
+    Announcement,
     Assignment,
+    AssignmentGroup,
+    CalendarEvent,
     Course,
+    Discussion,
+    Enrollment,
     File,
     Module,
     ModuleItem,
+    Page,
     PaginatedResponse,
     PlannerItem,
     Quiz,
+    Submission,
+    Tab,
 )
 from canvas_lms_mcp.utils import paginate_response
 
@@ -89,7 +97,9 @@ async def get_course_syllabus(
         Course syllabus as string
     """
     client = CanvasClient.get_instance()
-    response = await client.get(f"/api/v1/courses/{course_id}/syllabus")
+    response = await client.get(
+        f"/api/v1/courses/{course_id}", params={"include[]": "syllabus_body"}
+    )
     return response.get("syllabus_body", "")
 
 
@@ -144,6 +154,7 @@ async def list_assignments(
         "past", "overdue", "undated", "ungraded", "unsubmitted", "upcoming", "future"
     ],
     order_by: Literal["due_at", "position", "name"],
+    include: Optional[List[str]] = None,
     page: int = 1,
     items_per_page: int = 10,
 ) -> PaginatedResponse:
@@ -154,6 +165,7 @@ async def list_assignments(
         course_id: Course ID
         bucket: Bucket to filter assignments by (past, overdue, undated, ungraded, unsubmitted, upcoming, future)
         order_by: Field to order assignments by (due_at, position, name)
+        include: Optional list of additional data to include (e.g., ["submission"] to see grade status)
         page: Page number (1-indexed)
         items_per_page: Number of items per page
 
@@ -166,6 +178,8 @@ async def list_assignments(
         params["bucket"] = bucket
     if order_by:
         params["order_by"] = order_by
+    if include:
+        params["include[]"] = include
 
     response = await client.get(
         f"/api/v1/courses/{course_id}/assignments", params=params
@@ -311,7 +325,7 @@ async def list_quizzes(
 async def get_module_items(
     course_id: int,
     module_id: int,
-) -> PaginatedResponse[ModuleItem]:
+) -> dict:
     """
     Get items for a module.
 
@@ -323,7 +337,8 @@ async def get_module_items(
     response = await client.get(
         f"/api/v1/courses/{course_id}/modules/{module_id}/items"
     )
-    return [ModuleItem.model_validate(item) for item in response]
+    items = [ModuleItem.model_validate(item).model_dump() for item in response]
+    return {"items": items, "total": len(items)}
 
 
 @mcp.tool()
@@ -344,6 +359,230 @@ async def get_file(
     client = CanvasClient.get_instance()
     response = await client.get(f"/api/v1/courses/{course_id}/files/{file_id}")
     return File.model_validate(response)
+
+
+@mcp.tool()
+async def get_page(
+    course_id: int,
+    page_slug: str,
+) -> Page:
+    """
+    Get a single page by its URL slug.
+
+    Args:
+        course_id: Course ID
+        page_slug: Page URL slug (e.g., "kurshandbok", "examination")
+
+    Returns:
+        Page object with title, body (HTML), and metadata
+    """
+    client = CanvasClient.get_instance()
+    response = await client.get(f"/api/v1/courses/{course_id}/pages/{page_slug}")
+    return Page.model_validate(response)
+
+
+@mcp.tool()
+async def list_submissions(
+    course_id: int,
+    include: Optional[List[str]] = None,
+    page: int = 1,
+    items_per_page: int = 10,
+) -> PaginatedResponse[Submission]:
+    """
+    List the current user's submissions for a course, including grades and feedback.
+
+    Args:
+        course_id: Course ID
+        include: Optional list of additional data (e.g., ["assignment", "submission_comments"])
+        page: Page number (1-indexed)
+        items_per_page: Number of items per page
+
+    Returns:
+        PaginatedResponse containing submissions with grades and comments
+    """
+    client = CanvasClient.get_instance()
+    params = {"student_ids[]": "self"}
+    if include:
+        params["include[]"] = include
+
+    response = await client.get(
+        f"/api/v1/courses/{course_id}/students/submissions", params=params
+    )
+
+    items = [Submission.model_validate(item) for item in response]
+    return await paginate_response(items, page, items_per_page)
+
+
+@mcp.tool()
+async def list_announcements(
+    course_ids: List[int],
+    page: int = 1,
+    items_per_page: int = 10,
+) -> PaginatedResponse[Announcement]:
+    """
+    List announcements for one or more courses.
+
+    Args:
+        course_ids: List of course IDs to fetch announcements for
+        page: Page number (1-indexed)
+        items_per_page: Number of items per page
+
+    Returns:
+        PaginatedResponse containing announcements
+    """
+    client = CanvasClient.get_instance()
+    params = {"context_codes[]": [f"course_{cid}" for cid in course_ids]}
+
+    response = await client.get("/api/v1/announcements", params=params)
+
+    items = [Announcement.model_validate(item) for item in response]
+    return await paginate_response(items, page, items_per_page)
+
+
+@mcp.tool()
+async def list_discussions(
+    course_id: int,
+    page: int = 1,
+    items_per_page: int = 10,
+) -> PaginatedResponse[Discussion]:
+    """
+    List discussion topics for a course.
+
+    Args:
+        course_id: Course ID
+        page: Page number (1-indexed)
+        items_per_page: Number of items per page
+
+    Returns:
+        PaginatedResponse containing discussion topics
+    """
+    client = CanvasClient.get_instance()
+    response = await client.get(f"/api/v1/courses/{course_id}/discussion_topics")
+
+    items = [Discussion.model_validate(item) for item in response]
+    return await paginate_response(items, page, items_per_page)
+
+
+@mcp.tool()
+async def get_discussion_view(
+    course_id: int,
+    discussion_id: int,
+) -> dict:
+    """
+    Get the full view of a discussion topic including all replies.
+
+    Args:
+        course_id: Course ID
+        discussion_id: Discussion topic ID
+
+    Returns:
+        Full discussion view with participants and all entries
+    """
+    client = CanvasClient.get_instance()
+    response = await client.get(
+        f"/api/v1/courses/{course_id}/discussion_topics/{discussion_id}/view"
+    )
+    return response
+
+
+@mcp.tool()
+async def list_calendar_events(
+    context_codes: List[str],
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    page: int = 1,
+    items_per_page: int = 10,
+) -> PaginatedResponse[CalendarEvent]:
+    """
+    List calendar events for courses.
+
+    Args:
+        context_codes: List of context codes (e.g., ["course_4538"])
+        start_date: Optional start date in ISO 8601 format
+        end_date: Optional end date in ISO 8601 format
+        page: Page number (1-indexed)
+        items_per_page: Number of items per page
+
+    Returns:
+        PaginatedResponse containing calendar events
+    """
+    client = CanvasClient.get_instance()
+    params = {"context_codes[]": context_codes}
+    if start_date:
+        params["start_date"] = start_date
+    if end_date:
+        params["end_date"] = end_date
+
+    response = await client.get("/api/v1/calendar_events", params=params)
+
+    items = [CalendarEvent.model_validate(item) for item in response]
+    return await paginate_response(items, page, items_per_page)
+
+
+@mcp.tool()
+async def get_enrollments() -> dict:
+    """
+    Get the current user's enrollments including grades.
+
+    Returns:
+        Dict with enrollment items including course IDs and grade data
+    """
+    client = CanvasClient.get_instance()
+    response = await client.get("/api/v1/users/self/enrollments")
+    items = [Enrollment.model_validate(item).model_dump() for item in response]
+    return {"items": items, "total": len(items)}
+
+
+@mcp.tool()
+async def list_assignment_groups(
+    course_id: int,
+) -> dict:
+    """
+    List assignment groups for a course (shows grade weighting/categories).
+
+    Args:
+        course_id: Course ID
+
+    Returns:
+        Dict with assignment group items
+    """
+    client = CanvasClient.get_instance()
+    response = await client.get(f"/api/v1/courses/{course_id}/assignment_groups")
+    items = [AssignmentGroup.model_validate(item).model_dump() for item in response]
+    return {"items": items, "total": len(items)}
+
+
+@mcp.tool()
+async def get_tabs(
+    course_id: int,
+) -> dict:
+    """
+    Get available tabs/navigation items for a course.
+
+    Args:
+        course_id: Course ID
+
+    Returns:
+        Dict with tab items showing available course sections
+    """
+    client = CanvasClient.get_instance()
+    response = await client.get(f"/api/v1/courses/{course_id}/tabs")
+    items = [Tab.model_validate(item).model_dump() for item in response]
+    return {"items": items, "total": len(items)}
+
+
+@mcp.tool()
+async def list_favorites() -> dict:
+    """
+    List the current user's favorite courses.
+
+    Returns:
+        Dict with favorite course items
+    """
+    client = CanvasClient.get_instance()
+    response = await client.get("/api/v1/users/self/favorites/courses")
+    items = [Course.model_validate(item).model_dump() for item in response]
+    return {"items": items, "total": len(items)}
 
 
 if __name__ == "__main__":

--- a/src/canvas_lms_mcp/schema.py
+++ b/src/canvas_lms_mcp/schema.py
@@ -72,6 +72,95 @@ class ModuleItem(BaseModel):
     url: Optional[str] = None
 
 
+class Page(BaseModel):
+    title: Optional[str] = None
+    body: Optional[str] = None
+    url: Optional[str] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    editing_roles: Optional[str] = None
+    published: Optional[bool] = None
+    front_page: Optional[bool] = None
+    html_url: Optional[str] = None
+
+
+class Submission(BaseModel):
+    id: int
+    assignment_id: Optional[int] = None
+    assignment: Optional[dict] = None
+    user_id: Optional[int] = None
+    grade: Optional[str] = None
+    score: Optional[float] = None
+    submitted_at: Optional[datetime] = None
+    graded_at: Optional[datetime] = None
+    workflow_state: Optional[str] = None
+    late: Optional[bool] = None
+    missing: Optional[bool] = None
+    excused: Optional[bool] = None
+    submission_comments: Optional[list] = None
+    html_url: Optional[str] = None
+
+
+class Announcement(BaseModel):
+    id: int
+    title: str
+    message: Optional[str] = None
+    posted_at: Optional[datetime] = None
+    author: Optional[dict] = None
+    html_url: Optional[str] = None
+    read_state: Optional[str] = None
+
+
+class Discussion(BaseModel):
+    id: int
+    title: str
+    message: Optional[str] = None
+    posted_at: Optional[datetime] = None
+    author: Optional[dict] = None
+    html_url: Optional[str] = None
+    read_state: Optional[str] = None
+    discussion_type: Optional[str] = None
+    published: Optional[bool] = None
+
+
+class CalendarEvent(BaseModel):
+    id: int
+    title: Optional[str] = None
+    description: Optional[str] = None
+    start_at: Optional[datetime] = None
+    end_at: Optional[datetime] = None
+    location_name: Optional[str] = None
+    context_code: Optional[str] = None
+    workflow_state: Optional[str] = None
+    html_url: Optional[str] = None
+
+
+class Enrollment(BaseModel):
+    id: int
+    course_id: Optional[int] = None
+    type: Optional[str] = None
+    enrollment_state: Optional[str] = None
+    grades: Optional[dict] = None
+    html_url: Optional[str] = None
+
+
+class AssignmentGroup(BaseModel):
+    id: int
+    name: Optional[str] = None
+    position: Optional[int] = None
+    group_weight: Optional[float] = None
+    rules: Optional[dict] = None
+
+
+class Tab(BaseModel):
+    id: str
+    label: Optional[str] = None
+    type: Optional[str] = None
+    html_url: Optional[str] = None
+    position: Optional[int] = None
+    visibility: Optional[str] = None
+
+
 class File(BaseModel):
     id: int
     name: Optional[str] = None


### PR DESCRIPTION
## Summary

- **Fix `get_course_syllabus`**: Was calling `/courses/{id}/syllabus` which doesn't exist in the Canvas API. Changed to `/courses/{id}?include[]=syllabus_body` which is the documented approach.
- **Fix `get_module_items`**: Returned a raw Python list, violating the MCP protocol requirement that `structured_content` must be a dict. Wrapped in `{"items": [...], "total": N}` and added `.model_dump()` conversion.
- **Add `User-Agent` header**: Canvas LMS will [reject requests without User-Agent starting 2026-03-21](https://community.instructure.com/en/categories/canvas-lms-changelog). The HTTP client now sends `User-Agent: canvas-lms-mcp/0.1.3`.
- **Add 10 new tools** covering pages, submissions, announcements, discussions, calendar events, enrollments, assignment groups, tabs, and favorites — all verified against a live Canvas instance.
- **Improve `list_assignments`** with optional `include[]` parameter to fetch submission status inline.

## Bug Details

### `get_course_syllabus` → 404
The endpoint `/api/v1/courses/{id}/syllabus` does not exist in the Canvas REST API. The correct way to fetch a syllabus is to request the course object with `?include[]=syllabus_body`, which returns the `syllabus_body` field as HTML.

### `get_module_items` → MCP protocol error
FastMCP requires tool return values to be dicts when using `structured_content`. The function returned `[ModuleItem(...), ...]` (a list), causing:
```
structured_content must be a dict or None. Got list: [...]
```
The data was present but unusable. Fixed by returning `{"items": [...], "total": N}` with `.model_dump()` serialization.

## New Tools

| Tool | Endpoint | Description |
|------|----------|-------------|
| `get_page` | `GET /courses/{id}/pages/{slug}` | Fetch course pages by URL slug |
| `list_submissions` | `GET /courses/{id}/students/submissions?student_ids[]=self` | Own submissions with grades/feedback |
| `list_announcements` | `GET /announcements?context_codes[]=course_{id}` | Course announcements |
| `list_discussions` | `GET /courses/{id}/discussion_topics` | Discussion topics |
| `get_discussion_view` | `GET /courses/{id}/discussion_topics/{id}/view` | Full thread with replies |
| `list_calendar_events` | `GET /calendar_events?context_codes[]=course_{id}` | Calendar events |
| `get_enrollments` | `GET /users/self/enrollments` | Enrollments with grade data |
| `list_assignment_groups` | `GET /courses/{id}/assignment_groups` | Grade weighting/categories |
| `get_tabs` | `GET /courses/{id}/tabs` | Course navigation items |
| `list_favorites` | `GET /users/self/favorites/courses` | Favorite courses |

## Test Plan

- [x] All 22 tools tested against live Canvas instance (canvas.du.se)
- [x] `get_course_syllabus` returns full HTML syllabus content
- [x] `get_module_items` returns clean `{"items": [...], "total": N}` dict
- [x] All new tools return valid structured responses
- [x] Python syntax validated via `ast.parse()`
- [ ] Upstream CI/tests (if any)

🤖 Generated with [Claude Code](https://claude.com/claude-code)